### PR TITLE
Date visibility

### DIFF
--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -15,7 +15,7 @@ import LazyLoad from 'react-lazyload';
 export default class Article extends React.Component {
 
   render() {
-    const { author, categories, date, id, link, title, featured_image, text_only } = this.props;
+    const { author, categories, date, link, title, featured_image, text_only } = this.props;
     let img_id = Math.random().toString(36).replace('0.', '');
     let featured_image_link = "/static/images/article-fallback.png";
     if (featured_image) {

--- a/components/Article.jsx
+++ b/components/Article.jsx
@@ -9,13 +9,13 @@ import * as React from 'react';
 import Link from 'next/link';
 
 // jquery
-import { loadImage } from '../utilities/app.utilities';
+import { loadImage, getArticleDateDisplay } from '../utilities/app.utilities';
 import LazyLoad from 'react-lazyload';
 
 export default class Article extends React.Component {
 
   render() {
-    const { author, categories, date, link, title, featured_image, text_only } = this.props;
+    const { author, categories, link, title, featured_image, text_only } = this.props;
     let img_id = Math.random().toString(36).replace('0.', '');
     let featured_image_link = "/static/images/article-fallback.png";
     if (featured_image) {
@@ -48,7 +48,7 @@ export default class Article extends React.Component {
                 className='article-block-author'></a>
             </Link>
             <p
-              dangerouslySetInnerHTML={{ __html: date.ago }}
+              dangerouslySetInnerHTML={{ __html: getArticleDateDisplay(this.props) }}
               className='article-block-published'
             />
           </div>
@@ -71,7 +71,7 @@ export default class Article extends React.Component {
                   className='article-block-author'></a>
               </Link>
               <p
-                dangerouslySetInnerHTML={{ __html: date.ago }}
+                dangerouslySetInnerHTML={{ __html: getArticleDateDisplay(this.props) }}
                 className='article-block-published'
               />
             </div>

--- a/components/ArticlesPreloaded.jsx
+++ b/components/ArticlesPreloaded.jsx
@@ -18,7 +18,6 @@ import {
 } from '../utilities/app.utilities.js';
 
 export default class ArticlesPreloaded extends React.Component {
-
   getArticles = () => {
     const { mode, data, category } = this.props;
     let categoryData = {};
@@ -28,10 +27,10 @@ export default class ArticlesPreloaded extends React.Component {
         id: 'latest',
         link: ''
       }
-    }
-    else {
+    } else {
       categoryData = data[0].categories.find(cat => cat.id === category);
     }
+
     let articles =
       data
         .sort((a, a2) => moment(a2.date).diff(a.date))

--- a/components/FeaturedArticle.jsx
+++ b/components/FeaturedArticle.jsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { Link } from '../routes';
 
 // jquery
-import { loadImage } from '../utilities/app.utilities';
+import { loadImage, getArticleDateDisplay } from '../utilities/app.utilities';
 /*
  * TODO: check if this.props.data.featured_media === 0
  * if so -> .article-block.text, otherwise .article-block.image
@@ -17,13 +17,13 @@ import { loadImage } from '../utilities/app.utilities';
 
 export default class FeaturedArticle extends React.Component {
   render() {
-    const { author, date, id, link, title, featured_image } = this.props.data;
+    const { author, id, link, title, featured_image } = this.props.data;
 
     let featured_image_link = "/static/images/article-fallback.png";
     if (featured_image) {
       featured_image_link = featured_image.article;
     }
-    
+
     let featuredImage = (<a>
         <img
           alt='Article'
@@ -31,7 +31,7 @@ export default class FeaturedArticle extends React.Component {
           id={`image-${id}`} src={featured_image_link}
           onLoad={() => loadImage(`image-${id}`)} />
       </a>);
-    
+
     return (
       <figure className='article-block featured-article'>
         <Link href={link}>
@@ -50,7 +50,7 @@ export default class FeaturedArticle extends React.Component {
                   className='article-block-author'></a>
               </Link>
               <p
-                dangerouslySetInnerHTML={{ __html: date.ago }}
+                dangerouslySetInnerHTML={{ __html: getArticleDateDisplay(this.props.data) }}
                 className='article-block-published'
               />
             </div>

--- a/components/LoadedArticle.jsx
+++ b/components/LoadedArticle.jsx
@@ -9,8 +9,8 @@ import * as React from 'react';
 import { Link } from '../routes';
 
 import {
-  loadImage
-} from '../utilities/app.utilities.js'; 
+  loadImage, getArticleDateDisplay
+} from '../utilities/app.utilities.js';
 
 import LazyLoad from 'react-lazyload';
 
@@ -46,11 +46,10 @@ export default class LoadedArticle extends React.Component {
           <Link href={link}><a dangerouslySetInnerHTML={{ __html: excerpt }}></a></Link>
           <div className="loaded-article-author-date">
             <Link href={author.link}><a><p className="author">{author.name}</p></a></Link>
-            <p>{date.ago}</p>
+            <p>{getArticleDateDisplay(this.props)}</p>
           </div>
         </div>
       </div>
     );
   }
 }
-

--- a/pages/ArticlePage.jsx
+++ b/pages/ArticlePage.jsx
@@ -101,7 +101,7 @@ export default class ArticlePage extends React.Component {
     let dateString = null;
     let dateToShow = article.acf['date-to-show'];
 
-    if (true || dateToShow === 'last_updated') {
+    if (dateToShow === 'last_updated') {
       let parsed = new Date(Date.parse(article.modified));
       dateString = `Last updated ${humanizeDate(parsed)}`;
     } else if (dateToShow === 'no_date') {

--- a/pages/ArticlePage.jsx
+++ b/pages/ArticlePage.jsx
@@ -22,7 +22,7 @@ import {
   loadImage,
   processArticleBody,
   loadDynamicArticleContent,
-  humanizeDate
+  getArticleDateDisplay
 } from '../utilities/app.utilities.js';
 
 /* eslint-disable space-before-function-paren */
@@ -97,19 +97,8 @@ export default class ArticlePage extends React.Component {
     description = description.replace('</p>', '');
     description = description.replace('\n', '');
 
-    let dot = '·';
-    let dateString = null;
-    let dateToShow = article.acf['date-to-show'];
-
-    if (dateToShow === 'last_updated') {
-      let parsed = new Date(Date.parse(article.modified));
-      dateString = `Last updated ${humanizeDate(parsed)}`;
-    } else if (dateToShow === 'no_date') {
-      dateString = '';
-      dot = '';
-    } else { // Default to original published date
-      dateString = article.date.ago;
-    }
+    let dateString = getArticleDateDisplay(article);
+    let dot = article.acf['date-to-show'] === 'no_date' ? '' : '·';
 
     return (
       <React.Fragment>

--- a/pages/ArticlePage.jsx
+++ b/pages/ArticlePage.jsx
@@ -24,7 +24,6 @@ import {
 /* eslint-disable camelcase */
 
 export default class ArticlePage extends React.Component {
-
   state = { scriptjsLoaderEnabled: false };
 
   static async getInitialProps({ query }) {
@@ -93,6 +92,20 @@ export default class ArticlePage extends React.Component {
     description = description.replace('</p>', '');
     description = description.replace('\n', '');
 
+    let dot = '·';
+    let dateString = null;
+    let dateToShow = article.acf['date-to-show'];
+
+    if (true || dateToShow === 'last_updated') {
+      let parsed = new Date(Date.parse(article.modified));
+      dateString = `Last updated ${humanizeDate(parsed)}`;
+    } else if (dateToShow === 'no_date') {
+      dateString = '';
+      dot = '';
+    } else { // Default to original published date
+      dateString = article.date.ago;
+    }
+
     return (
       <React.Fragment>
         <Head>
@@ -117,7 +130,7 @@ export default class ArticlePage extends React.Component {
               <h1 dangerouslySetInnerHTML={{ __html: article.title }}></h1>
               <div className='details'>
                 <span className='accent author'><Link href={article.author.link}><a>{article.author.name}</a></Link></span>
-                <span className='dot'>·</span>
+                <span className='dot'>{dot}</span>
                 {
                   article.author.user_twitter ?
                     <React.Fragment>
@@ -127,7 +140,7 @@ export default class ArticlePage extends React.Component {
                     : ''
                 }
                 <span
-                  dangerouslySetInnerHTML={{ __html: article.date.ago }}
+                  dangerouslySetInnerHTML={{ __html: dateString }}
                 />
               </div>
               <div className="addthis_inline_share_toolbox"></div>
@@ -167,4 +180,31 @@ export default class ArticlePage extends React.Component {
       </React.Fragment>
     );
   }
+}
+
+let monthLookup = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+]
+
+/**
+ *
+ * @param {Date} dateObj
+ */
+function humanizeDate(dateObj) {
+  let month = monthLookup[dateObj.getMonth()];
+  let date = dateObj.getDate();
+  let year = dateObj.getFullYear();
+
+  return `${month} ${date}, ${year}`
 }

--- a/pages/ArticlePage.jsx
+++ b/pages/ArticlePage.jsx
@@ -17,7 +17,11 @@ import SponsoredLinks from '../components/SponsoredLinks';
 import DonateBar from '../components/DonateBar';
 
 import {
-  request, parseDate, loadImage, processArticleBody, loadDynamicArticleContent, chooseArticleDates
+  request,
+  parseDate,
+  loadImage,
+  processArticleBody,
+  loadDynamicArticleContent
 } from '../utilities/app.utilities.js';
 
 /* eslint-disable space-before-function-paren */

--- a/pages/ArticlePage.jsx
+++ b/pages/ArticlePage.jsx
@@ -21,7 +21,8 @@ import {
   parseDate,
   loadImage,
   processArticleBody,
-  loadDynamicArticleContent
+  loadDynamicArticleContent,
+  humanizeDate
 } from '../utilities/app.utilities.js';
 
 /* eslint-disable space-before-function-paren */
@@ -184,31 +185,4 @@ export default class ArticlePage extends React.Component {
       </React.Fragment>
     );
   }
-}
-
-let monthLookup = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December'
-]
-
-/**
- *
- * @param {Date} dateObj
- */
-function humanizeDate(dateObj) {
-  let month = monthLookup[dateObj.getMonth()];
-  let date = dateObj.getDate();
-  let year = dateObj.getFullYear();
-
-  return `${month} ${date}, ${year}`
 }

--- a/utilities/app.utilities.js
+++ b/utilities/app.utilities.js
@@ -340,3 +340,36 @@ export const getArticlePreviewData = async (wp_id, wp_nonce) => {
 
   return articleData;
 }
+
+const monthLookup = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+]
+
+/**
+ * Humanizes a date object into the following format: `Month Day, Year`.
+ *
+ * i.e. can return "March 20, 2020"
+ * @param {Date} dateObj
+ */
+export function humanizeDate(dateObj) {
+  let month = monthLookup[dateObj.getMonth()];
+  let date = dateObj.getDate();
+  let year = dateObj.getFullYear();
+
+  return `${month} ${date}, ${year}`
+}
+
+export function getArticleDateDisplay(article) {
+
+}

--- a/utilities/app.utilities.js
+++ b/utilities/app.utilities.js
@@ -360,7 +360,9 @@ const monthLookup = [
  * Humanizes a date object into the following format: `Month Day, Year`.
  *
  * i.e. can return "March 20, 2020"
+ *
  * @param {Date} dateObj
+ * @returns {string}
  */
 export function humanizeDate(dateObj) {
   let month = monthLookup[dateObj.getMonth()];

--- a/utilities/app.utilities.js
+++ b/utilities/app.utilities.js
@@ -372,6 +372,22 @@ export function humanizeDate(dateObj) {
   return `${month} ${date}, ${year}`
 }
 
+/**
+ * Gets the date string to display for a given article. An article should have the
+ * advanced custom field "date-to-show"
+ *
+ * @param {Object} article
+ * @returns {string}
+ */
 export function getArticleDateDisplay(article) {
+  let dateToShow = article.acf['date-to-show'];
 
+  if (dateToShow === 'last_updated') {
+    let parsed = new Date(Date.parse(article.modified));
+    return `Last updated ${humanizeDate(parsed)}`;
+  } else if (dateToShow === 'no_date') {
+    return '';
+  } else { // Default to original published date
+    return article.date.ago;
+  }
 }


### PR DESCRIPTION
Added support to change how an article's date is displayed based off of an article's ACF (advanced custom field)

Articles can either have:
* Original published date (default)
* Last updated/modified date
* No date