### PR TITLE
Looking back 2020 redirect

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/.next": true
+  }
+}

--- a/server.js
+++ b/server.js
@@ -15,6 +15,10 @@ app.prepare()
       adsTxtPromise.then(data => res.send(data));
     });
 
+    server.get('/looking-back-2020', (_, res) => {
+      res.redirect('https://wps3.dbknews.com/uploads/2020/04/Looking_Back_2020.pdf');
+    });
+
     server.get('*', (req, res) => {
       return handle(req, res);
     });


### PR DESCRIPTION
Added a redirect route from `/looking-back-2020` to a PDF stored on one of our S3 buckets. This will later be replaced by something more dynamic and runtime-based.